### PR TITLE
Postman collection fixes (enabled running as collection)

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -68,50 +68,6 @@
 			"response": []
 		},
 		{
-			"name": "List User Assets",
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer {{access_token}}"
-					},
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					},
-					{
-						"key": "X-IBM-Client-ID",
-						"value": "{{X-IBM-Client-ID}}"
-					},
-					{
-						"key": "X-IBM-Client-Secret",
-						"value": "{{X-IBM-Client-Secret}}"
-					},
-					{
-						"key": "X-Response-Scenarios",
-						"value": "AuthorizationSkipAccessControl"
-					}
-				],
-				"body": {},
-				"url": {
-					"raw": "https://api.nordeaopenbanking.com/v1/assets",
-					"protocol": "https",
-					"host": [
-						"api",
-						"nordeaopenbanking",
-						"com"
-					],
-					"path": [
-						"v1",
-						"assets"
-					]
-				},
-				"description": ""
-			},
-			"response": []
-		},
-		{
 			"name": "Exchange Token",
 			"event": [
 				{
@@ -171,6 +127,65 @@
 			},
 			"response": []
 		},
+		{
+			"name": "List User Assets",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "7f1d6303-a8e3-4096-a4d9-e15a12494196",
+						"type": "text/javascript",
+						"exec": [
+							"pm.test(\"Request Passes\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{access_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "X-IBM-Client-ID",
+						"value": "{{X-IBM-Client-ID}}"
+					},
+					{
+						"key": "X-IBM-Client-Secret",
+						"value": "{{X-IBM-Client-Secret}}"
+					},
+					{
+						"key": "X-Response-Scenarios",
+						"value": "AuthorizationSkipAccessControl"
+					}
+				],
+				"body": {},
+				"url": {
+					"raw": "https://api.nordeaopenbanking.com/v1/assets",
+					"protocol": "https",
+					"host": [
+						"api",
+						"nordeaopenbanking",
+						"com"
+					],
+					"path": [
+						"v1",
+						"assets"
+					]
+				},
+				"description": ""
+			},
+			"response": []
+		},
+		
 		{
 			"name": "Get Account",
 			"event": [

--- a/postman.json
+++ b/postman.json
@@ -99,7 +99,7 @@
 				],
 				"body": {},
 				"url": {
-					"raw": "https://api.nordeaopenbanking.com/v1/authentication/access_token?code=ZXlKbGJtTWlPaUpCTVRJNFIwTk5JaXdpWVd4bklqb2laR2x5SW4wLi5ZeGJSVDZ2RkdxeUVNb0xtLjg4cFo3eXl1cHlISnk5RHNYWnZTQzBIRTJJTWZ4c1AtcVFrRF9lNlRzdG5VVncwNVlQckx0UGtjMk5SMzAtRVJaRFB5YmNLSk8wTnpXSVBxUTBYMFhsNVZoYWh6Q1pYYVY3U1ByMTF6bVQ0ck5mdmRaampTeFdFaWhSay1PaUs1WXNlUGtVRUUyc2o2WTFzYk42Z0U4alJvNHp6RUVkRmFTcGh1Y3Ricjh1UWJtejdhYnl4aHZRdnpGQ3RRUVg2NVdPT1VYRjNBR2J0dmNEZUJZS1lCN0dxaGNwd2dwYi14S3VDUmxaUjFJSllKUklvR3U1MUh4T2pac3FRQjdTcHNKa2FvaXlyNnEtbW1COWJ2LWtGMGVxYU9vODQzMTR0ODVrVzRNMHFZcFJvcDBZUG1kZUpYaDZnQUdlRmxsZm8tZHQxRWFWMUlIWlBVaVAtaFlLTDhSaDEyWkY3LS5KeU1oMFR4Mk1nUkRfVVdJWm04ODhB&redirect_uri=http://httpbin.org/post",
+					"raw": "https://api.nordeaopenbanking.com/v1/authentication/access_token?code={{code}}&redirect_uri=http://httpbin.org/post",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -194,10 +194,7 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"var jsonData = JSON.parse(responseBody);\r",
-							"\r",
-							"postman.setEnvironmentVariable(\"paymentId\", \r",
-							"    jsonData.response.id);"
+							""
 						]
 					}
 				}
@@ -343,11 +340,6 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"var jsonData = JSON.parse(responseBody);\r",
-							"\r",
-							"postman.setEnvironmentVariable(\"paymentId\", \r",
-							"    jsonData.response._id);\r",
-							"\r",
 							""
 						]
 					}
@@ -408,10 +400,7 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"var jsonData = JSON.parse(responseBody);\r",
-							"\r",
-							"postman.setEnvironmentVariable(\"paymentId\", \r",
-							"    jsonData.response.id);"
+							""
 						]
 					}
 				}
@@ -466,10 +455,6 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"var jsonData = JSON.parse(responseBody);",
-							"",
-							"postman.setEnvironmentVariable(\"payment-id\", ",
-							"    jsonData.response._id);",
 							""
 						]
 					}
@@ -525,10 +510,6 @@
 					"script": {
 						"type": "text/javascript",
 						"exec": [
-							"var jsonData = JSON.parse(responseBody);",
-							"",
-							"postman.setEnvironmentVariable(\"payment-id\", ",
-							"    jsonData.response._id);",
 							""
 						]
 					}

--- a/postman.json
+++ b/postman.json
@@ -158,8 +158,7 @@
 					"query": [
 						{
 							"key": "code",
-							"value": "ZXlKbGJtTWlPaUpCTVRJNFIwTk5JaXdpWVd4bklqb2laR2x5SW4wLi5ZeGJSVDZ2RkdxeUVNb0xtLjg4cFo3eXl1cHlISnk5RHNYWnZTQzBIRTJJTWZ4c1AtcVFrRF9lNlRzdG5VVncwNVlQckx0UGtjMk5SMzAtRVJaRFB5YmNLSk8wTnpXSVBxUTBYMFhsNVZoYWh6Q1pYYVY3U1ByMTF6bVQ0ck5mdmRaampTeFdFaWhSay1PaUs1WXNlUGtVRUUyc2o2WTFzYk42Z0U4alJvNHp6RUVkRmFTcGh1Y3Ricjh1UWJtejdhYnl4aHZRdnpGQ3RRUVg2NVdPT1VYRjNBR2J0dmNEZUJZS1lCN0dxaGNwd2dwYi14S3VDUmxaUjFJSllKUklvR3U1MUh4T2pac3FRQjdTcHNKa2FvaXlyNnEtbW1COWJ2LWtGMGVxYU9vODQzMTR0ODVrVzRNMHFZcFJvcDBZUG1kZUpYaDZnQUdlRmxsZm8tZHQxRWFWMUlIWlBVaVAtaFlLTDhSaDEyWkY3LS5KeU1oMFR4Mk1nUkRfVVdJWm04ODhB",
-							"equals": true
+							"value": "{{code}}"
 						},
 						{
 							"key": "redirect_uri",


### PR DESCRIPTION
This PR contains the following changes to the collection:

1. Exchange Token request is fixed to use the code acquired in the first request instead of hard-coded value
2. Order of requests is changed in the beginning of the collection so that Start Oauth and Exchange Token requests are executed sequntially. This enables running the collection from runner.
3. Due to an obvious copy-paste error major portion of the requests had test code that was referring to Payment initiatiation scenario. This caused errors in the request processing when collection was run in the runner. Fixed by removing the invalid test code from those requests that do not need it.